### PR TITLE
Modernize integration: async, UI config flow, tests, docs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -21,6 +21,18 @@ jobs:
       - name: Ruff format check
         run: ruff format --check custom_components
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install test dependencies
+        run: pip install -r requirements_test.txt
+      - name: Run pytest
+        run: pytest
+
   hassfest:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,0 +1,38 @@
+name: Quality
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install Ruff
+        run: pip install ruff
+      - name: Ruff check
+        run: ruff check custom_components
+      - name: Ruff format check
+        run: ruff format --check custom_components
+
+  hassfest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Hassfest validation
+        uses: home-assistant/actions/hassfest@master
+
+  hacs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: HACS validation
+        uses: hacs/action@main
+        with:
+          category: integration

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -48,3 +48,5 @@ jobs:
         uses: hacs/action@main
         with:
           category: integration
+          # 'brands' requires the domain to be in home-assistant/brands (separate repo).
+          ignore: brands

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,22 @@
+name: Security
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '0 9 * * 1'  # Weekly Monday
+
+jobs:
+  secrets-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect secrets
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          extra_args: --only-verified

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,12 @@ build/
 .vscode/settings.json
 .DS_Store
 
+# Local HA dev environment (scripts/dev-ha.sh)
+dev-config/
+
+# Freebox app token from scripts/freebox-check.py - secret, NEVER commit
+.freebox-token.json
+
 # Claude - not shipped with the integration
 CLAUDE.md
 .claude/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,37 @@
+# Environment files - NEVER commit
+.env
+.env.*
+!.env.example
+
+# Secrets
+*.pem
+*.key
+*.p12
+credentials.json
+secrets.json
+service-account*.json
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+.venv/
+venv/
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/
+*.egg-info/
+
+# Build outputs
+dist/
+build/
+
+# IDE
+.idea/
+.vscode/settings.json
+.DS_Store
+
+# Claude - not shipped with the integration
+CLAUDE.md
+.claude/
+_project_specs/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-added-large-files
+      - id: detect-private-key
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.6
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.6.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]

--- a/README.md
+++ b/README.md
@@ -31,9 +31,19 @@ It's doesn't works on Freebox mini 4K. This one doesn't have a remote code.
 This conponent use the old remote API, but since short time, Free is developping new API unrelated to remote (control player to open URL ect…)
 
 ## Configuration
-Once installed, the Freebox Player component needs to be configured in order to work.
 
-Edit `configuration.yaml` file and add the following:
+Configuration is done through the Home Assistant UI.
+
+1. Go to **Settings** → **Devices & Services** → **Add Integration**.
+2. Search for **Freebox Player**.
+3. Enter the **Host** (IP address of the player) and the **remote control code**.
+
+> **YAML is deprecated.** If you previously configured the integration in
+> `configuration.yaml`, it will be imported automatically on the next restart;
+> you can then remove the `freebox_player:` block.
+
+<details>
+<summary>Legacy YAML (auto-imported, then remove)</summary>
 
 ```yaml
 # Example configuration.yaml entry
@@ -42,7 +52,9 @@ freebox_player:
   host: 192.168.0.xx
 ```
 
-Where `remote_code` is the free authorization code for remote and `host` the ip of the player device.
+</details>
+
+Where `remote_code` is the free authorization code for the remote and `host` the IP of the player device.
 
 ### How to get the remote control code
 

--- a/README.md
+++ b/README.md
@@ -1,147 +1,146 @@
-# Freebox Player Custom Component for Home Assistant
+# Freebox Player — Custom Component for Home Assistant
 
 [![](https://img.shields.io/github/release/Pouzor/freebox_player/all.svg?style=for-the-badge)](https://github.com/Pouzor/freebox_player)
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/hacs/integration)
 [![](https://img.shields.io/github/license/Pouzor/freebox_player?style=for-the-badge)](LICENSE)
 
-Based on pure-python library, this custom component enables remote control on your Freebox Player devices.
+Control your **Freebox Player** from Home Assistant. This component emulates the
+infrared remote over the network, using the player's `remote_control` HTTP API.
 
-This component is tested on Freebox Delta, but should work too on Freebox Revolution and Crystal (feedsback will be appreciated).
+## Compatibility
 
-It's doesn't works on Freebox mini 4K. This one doesn't have a remote code.
+This component targets the **classic Freebox Players** that expose the legacy
+remote-control API. The newer Android-TV players (Pop, Mini 4K) do **not** expose
+that API — use Home Assistant's built-in **[Android TV Remote][androidtv]**
+integration for those instead (see [below](#freebox-pop--mini-4k)).
 
+| Player | Supported here | How to control |
+|--------|:--------------:|----------------|
+| Freebox Révolution | ✅ | This component (remote code) |
+| Freebox Delta (player) | ✅ | This component (remote code) |
+| Freebox One / Crystal | ✅ | This component (remote code) |
+| Freebox **Pop** | ❌ | [Android TV Remote][androidtv] (core integration) |
+| Freebox **Mini 4K** | ❌ | [Android TV Remote][androidtv] (core integration) |
+
+> The remote code lives on the **Player** (the TV box), not on the server. In a
+> Delta-server + Pop-player setup, the player is a Pop → use Android TV Remote.
 
 ## Installation
 
-### HACS Install
+### HACS
 
-1. Search for `Freebox Player` under `Integrations` in the HACS Store tab.
-2. **You will need to restart after installation for the component to start working.**
-3. Configure the integation (see Configuration section)
-
-
-## Features
-* Supports On / Off 
-* Supports changing channels
-* Supports volume changes
-* Supports navigation controls
-* Even more incoming
-
-## Still under developpment
-This conponent use the old remote API, but since short time, Free is developping new API unrelated to remote (control player to open URL ect…)
+1. In HACS, go to **Integrations** and search for **Freebox Player**.
+2. Install, then **restart Home Assistant**.
+3. Configure it (see below).
 
 ## Configuration
 
-Configuration is done through the Home Assistant UI.
+Configuration is done through the UI.
 
-1. Go to **Settings** → **Devices & Services** → **Add Integration**.
+1. **Settings → Devices & Services → Add Integration**.
 2. Search for **Freebox Player**.
 3. Enter the **Host** (IP address of the player) and the **remote control code**.
 
-> **YAML is deprecated.** If you previously configured the integration in
-> `configuration.yaml`, it will be imported automatically on the next restart;
-> you can then remove the `freebox_player:` block.
+> YAML is deprecated. An existing `freebox_player:` block in `configuration.yaml`
+> is imported automatically on the next restart; you can then remove it.
 
-<details>
-<summary>Legacy YAML (auto-imported, then remove)</summary>
+### How to find the remote control code
+
+On the Player: **Main menu → Réglages → Système → Informations** → line
+**« Code télécommande réseau »** (8 digits).
+
+## Usage
+
+Call the `freebox_player.remote` service with a `code`:
 
 ```yaml
-# Example configuration.yaml entry
-freebox_player:
-  remote_code: 00000000
-  host: 192.168.0.xx
+service: freebox_player.remote
+data:
+  code: "power"
 ```
 
-</details>
+### Sending several codes
 
-Where `remote_code` is the free authorization code for the remote and `host` the IP of the player device.
+Separate codes with a comma to send a sequence (e.g. channel `123`):
 
-### How to get the remote control code
-
-Go to 
-* `Freebox main menu` >> `Parameters` >> `General Information` For old box
-* `Freebox main menu` >> `Réglages` >> `Systeme Information` For Delta 
-
-## How to use the remote
-
-To send remote code to the player, just call the service `freebox_player.remote` with the code in parameter: 
 ```yaml
-code: "power"
+service: freebox_player.remote
+data:
+  code: "1,2,3"
 ```
 
-### Mutiple code
+## Freebox Pop / Mini 4K
 
-If you want to send multiple code like `123` for example, you need to split each code with a comma :
+These run **Android TV** and ignore the legacy remote API. Control them with the
+official **[Android TV Remote][androidtv]** integration — it gives directional
+keys, power, volume, media and app launching (more than this component does):
+
+1. **Settings → Devices & Services → Add Integration → Android TV Remote**.
+2. Enter the player's **IP address**.
+3. Type the **pairing code shown on the TV**.
+
 ```yaml
-code: "1,2,3"
+service: remote.send_command
+target:
+  entity_id: remote.freebox_player_pop
+data:
+  command: "DPAD_UP"   # DPAD_CENTER, BACK, HOME, POWER, ...
 ```
 
-Or you call multiple times the service for each number (`1` && `2` && `3`)
+[androidtv]: https://www.home-assistant.io/integrations/androidtv_remote/
 
+## Button list
 
-## Button List
+* "red" — Bouton rouge
+* "green" — Bouton vert
+* "blue" — Bouton bleu
+* "yellow" — Bouton jaune
+* "power" — Power
+* "list" — Liste des chaînes
+* "tv" — TV
+* "1" … "9", "0" — Pavé numérique
+* "back" — Retour
+* "swap" — Swap
+* "info" — Info
+* "epg" — EPG (fct+)
+* "mail" — Mail
+* "media" — Media (fct+)
+* "help" — Help
+* "options" — Options (fct+)
+* "pip" — PiP
+* "vol_inc" / "vol_dec" — Volume +/-
+* "ok" — OK
+* "up" / "down" / "left" / "right" — Navigation
+* "prgm_inc" / "prgm_dec" — Programme +/-
+* "mute" — Sourdine
+* "home" — Free
+* "rec" — Enregistrement
+* "bwd" — Retour arrière (<<)
+* "prev" — Précédent (|<<)
+* "play" — Lecture / Pause
+* "fwd" — Avance rapide (>>)
+* "next" — Suivant (>>|)
+* "replay", "vod", "whatson", "records", "youtube", "radios", "canalvod", "netflix"
 
-* "red" // Bouton rouge
-* "green" // Bouton vert
-* "blue" // Bouton bleu
-* "yellow" // Bouton jaune
+## Development
 
-* "power" // Bouton Power
-* "list" // Affichage de la liste des chaines
-* "tv" // Bouton tv
+Local Home Assistant in Docker with this integration mounted:
 
-* "1" // Bouton 1
-* "2" // Bouton 2
-* "3" // Bouton 3
-* "4" // Bouton 4
-* "5" // Bouton 5
-* "6" // Bouton 6
-* "7" // Bouton 7
-* "8" // Bouton 8
-* "9" // Bouton 9
+```bash
+./scripts/dev-ha.sh          # start HA at http://localhost:8123, follow logs
+./scripts/dev-ha.sh restart  # pick up code edits
+./scripts/dev-ha.sh stop
+```
 
-* "back" // Bouton jaune (retour)
-* "0" // Bouton 0
-* "swap" // Bouton swap
+Run the tests:
 
-* "info" // Bouton info
-* "epg" // Bouton epg (fct+)
-* "mail" // Bouton mail
-* "media" // Bouton media (fct+)
-* "help" // Bouton help
-* "options" // Bouton options (fct+)
-* "pip" // Bouton pip
+```bash
+pip install -r requirements_test.txt
+pytest
+```
 
-* "vol_inc" // Bouton volume +
-* "vol_dec" // Bouton volume -
+Diagnose whether a player exposes the Freebox Player API (useful for Pop owners):
 
-* "ok" // Bouton ok
-* "up" // Bouton haut
-* "right" // Bouton droite
-* "down" // Bouton bas
-* "left" // Bouton gauche
-
-* "prgm_inc" //Bouton programme +
-* "prgm_dec" // Bouton programme -
-
-* "mute" // Bouton sourdine
-* "home" // Bouton Free
-* "rec" // Bouton Rec
-
-* "bwd" // Bouton << retour arrière
-* "prev" // Bouton |<< précédent
-* "play" // Bouton Lecture / Pause
-* "fwd" // Bouton >> avance rapide
-* "next" // Bouton >>| suivant
-
-* "tv"
-* "replay"
-* "vod"
-* "whatson"
-* "records"
-* "media"
-* "youtube"
-* "radios"
-* "canalvod"
-* "pip"
-* "netflix"
+```bash
+python3 scripts/freebox-check.py
+```

--- a/custom_components/freebox_player/__init__.py
+++ b/custom_components/freebox_player/__init__.py
@@ -1,60 +1,69 @@
-"""
-Freebox Player Controller
+"""Freebox Player remote control integration.
+
 https://github.com/Pouzor/freebox_player
 """
 
+from __future__ import annotations
+
 import logging
-import requests
+
+import aiohttp
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
-from homeassistant.helpers.aiohttp_client import async_create_clientsession
-from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.typing import ConfigType
 
 DOMAIN = "freebox_player"
-player_path = "/pub/remote_control"
+CONF_REMOTE_CODE = "remote_code"
+REMOTE_PATH = "/pub/remote_control"
+SERVICE_REMOTE = "remote"
+
+_LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
-            {vol.Required(CONF_HOST): cv.string, vol.Required("remote_code"): cv.string}
+            {
+                vol.Required(CONF_HOST): cv.string,
+                vol.Required(CONF_REMOTE_CODE): cv.string,
+            }
         )
     },
     extra=vol.ALLOW_EXTRA,
 )
 
-REMOTE_SCHEMA = vol.Schema(
-    {
-        vol.Optional("code"): cv.string
-    }
-)
+SERVICE_REMOTE_SCHEMA = vol.Schema({vol.Required("code"): cv.string})
 
-_LOGGER = logging.getLogger(__name__)
 
-async def async_setup(hass, config):
-    """Set up the Freebox player component."""
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Freebox Player component from YAML configuration."""
     conf = config.get(DOMAIN)
+    if conf is None:
+        return True
 
-    if conf is not None:
-        host = conf.get(CONF_HOST)
-        remote_code = conf.get("remote_code")
-        global player_path
-        player_path = "http://"+host+player_path+"?code="+remote_code+"&key="
+    host: str = conf[CONF_HOST]
+    remote_code: str = conf[CONF_REMOTE_CODE]
+    base_url = f"http://{host}{REMOTE_PATH}"
+    session = async_get_clientsession(hass)
 
-        await async_setup_freebox_player(hass, config, host, remote_code)
+    async def async_handle_remote(call: ServiceCall) -> None:
+        """Send one or more remote key codes to the player.
 
+        Codes are comma-separated to emulate a sequence (e.g. "1,2,3").
+        """
+        codes = [code.strip() for code in call.data["code"].split(",") if code.strip()]
+        for code in codes:
+            try:
+                async with session.get(
+                    base_url, params={"code": remote_code, "key": code}
+                ) as response:
+                    response.raise_for_status()
+            except aiohttp.ClientError as err:
+                _LOGGER.error("Failed to send remote code '%s': %s", code, err)
+
+    hass.services.async_register(
+        DOMAIN, SERVICE_REMOTE, async_handle_remote, schema=SERVICE_REMOTE_SCHEMA
+    )
     return True
-
-async def async_setup_freebox_player(hass, config, host, port):
-
-    async def async_freebox_player_remote(call):
-        """Handle old player control (remote emulation)"""
-
-        code_list = call.data.get('code')
-
-        code_array = code_list.split(',')
-
-        """Handle multiple codes, separated by comma"""
-        for code in code_array:
-            await hass.async_add_executor_job(requests.get, player_path+code, 'verify=False')
-
-    hass.services.async_register(DOMAIN, "remote", async_freebox_player_remote)

--- a/custom_components/freebox_player/__init__.py
+++ b/custom_components/freebox_player/__init__.py
@@ -10,15 +10,13 @@ import logging
 import aiohttp
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
-DOMAIN = "freebox_player"
-CONF_REMOTE_CODE = "remote_code"
-REMOTE_PATH = "/pub/remote_control"
-SERVICE_REMOTE = "remote"
+from .const import CONF_REMOTE_CODE, DOMAIN, REMOTE_PATH, SERVICE_REMOTE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,13 +36,25 @@ SERVICE_REMOTE_SCHEMA = vol.Schema({vol.Required("code"): cv.string})
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the Freebox Player component from YAML configuration."""
-    conf = config.get(DOMAIN)
-    if conf is None:
-        return True
+    """Set up the integration from YAML by importing into a config entry.
 
-    host: str = conf[CONF_HOST]
-    remote_code: str = conf[CONF_REMOTE_CODE]
+    YAML configuration is deprecated; this only migrates an existing
+    `configuration.yaml` block into a UI config entry once.
+    """
+    conf = config.get(DOMAIN)
+    if conf is not None:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
+            )
+        )
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Freebox Player from a config entry."""
+    host: str = entry.data[CONF_HOST]
+    remote_code: str = entry.data[CONF_REMOTE_CODE]
     base_url = f"http://{host}{REMOTE_PATH}"
     session = async_get_clientsession(hass)
 
@@ -66,4 +76,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     hass.services.async_register(
         DOMAIN, SERVICE_REMOTE, async_handle_remote, schema=SERVICE_REMOTE_SCHEMA
     )
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry and remove the registered service."""
+    hass.services.async_remove(DOMAIN, SERVICE_REMOTE)
     return True

--- a/custom_components/freebox_player/config_flow.py
+++ b/custom_components/freebox_player/config_flow.py
@@ -1,0 +1,39 @@
+"""Config flow for the Freebox Player integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST
+
+from .const import CONF_REMOTE_CODE, DOMAIN
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_REMOTE_CODE): str,
+    }
+)
+
+
+class FreeboxPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Freebox Player."""
+
+    VERSION = 1
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        """Handle the user-initiated setup step."""
+        if user_input is not None:
+            await self.async_set_unique_id(user_input[CONF_HOST])
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(title=user_input[CONF_HOST], data=user_input)
+
+        return self.async_show_form(step_id="user", data_schema=STEP_USER_DATA_SCHEMA)
+
+    async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
+        """Import configuration from configuration.yaml (deprecated)."""
+        await self.async_set_unique_id(import_data[CONF_HOST])
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(title=import_data[CONF_HOST], data=import_data)

--- a/custom_components/freebox_player/const.py
+++ b/custom_components/freebox_player/const.py
@@ -1,0 +1,6 @@
+"""Constants for the Freebox Player integration."""
+
+DOMAIN = "freebox_player"
+CONF_REMOTE_CODE = "remote_code"
+REMOTE_PATH = "/pub/remote_control"
+SERVICE_REMOTE = "remote"

--- a/custom_components/freebox_player/manifest.json
+++ b/custom_components/freebox_player/manifest.json
@@ -2,9 +2,11 @@
     "domain": "freebox_player",
     "name": "Freebox Player",
     "documentation": "https://github.com/Pouzor/freebox_player",
+    "config_flow": true,
+    "single_config_entry": true,
     "dependencies": [],
     "codeowners": ["@Pouzor"],
     "requirements": [],
-    "version": "1.0.7",
+    "version": "1.1.0",
     "iot_class": "local_push"
   }

--- a/custom_components/freebox_player/manifest.json
+++ b/custom_components/freebox_player/manifest.json
@@ -1,12 +1,13 @@
 {
-    "domain": "freebox_player",
-    "name": "Freebox Player",
-    "documentation": "https://github.com/Pouzor/freebox_player",
-    "config_flow": true,
-    "single_config_entry": true,
-    "dependencies": [],
-    "codeowners": ["@Pouzor"],
-    "requirements": [],
-    "version": "1.1.0",
-    "iot_class": "local_push"
-  }
+  "domain": "freebox_player",
+  "name": "Freebox Player",
+  "codeowners": ["@Pouzor"],
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://github.com/Pouzor/freebox_player",
+  "iot_class": "local_push",
+  "issue_tracker": "https://github.com/Pouzor/freebox_player/issues",
+  "requirements": [],
+  "single_config_entry": true,
+  "version": "1.1.0"
+}

--- a/custom_components/freebox_player/manifest.json
+++ b/custom_components/freebox_player/manifest.json
@@ -5,6 +5,6 @@
     "dependencies": [],
     "codeowners": ["@Pouzor"],
     "requirements": [],
-    "version": "1.0.6",
+    "version": "1.0.7",
     "iot_class": "local_push"
   }

--- a/custom_components/freebox_player/services.yaml
+++ b/custom_components/freebox_player/services.yaml
@@ -1,6 +1,11 @@
 remote:
-  description: Call remote code to the Freebox Player
+  name: Send remote code
+  description: Send one or more key codes to the Freebox Player (comma-separated for a sequence).
   fields:
     code:
-      description: Code Number
-      example: 'power'
+      name: Code
+      description: Remote key code, or several separated by commas (e.g. "1,2,3").
+      required: true
+      example: "power"
+      selector:
+        text:

--- a/custom_components/freebox_player/strings.json
+++ b/custom_components/freebox_player/strings.json
@@ -1,0 +1,17 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Freebox Player",
+        "description": "Enter your Freebox Player host (IP address) and the remote control code.",
+        "data": {
+          "host": "Host",
+          "remote_code": "Remote control code"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "Freebox Player is already configured."
+    }
+  }
+}

--- a/custom_components/freebox_player/translations/en.json
+++ b/custom_components/freebox_player/translations/en.json
@@ -1,0 +1,17 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Freebox Player",
+        "description": "Enter your Freebox Player host (IP address) and the remote control code.",
+        "data": {
+          "host": "Host",
+          "remote_code": "Remote control code"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "Freebox Player is already configured."
+    }
+  }
+}

--- a/custom_components/freebox_player/translations/fr.json
+++ b/custom_components/freebox_player/translations/fr.json
@@ -1,0 +1,17 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Freebox Player",
+        "description": "Saisissez l'hôte (adresse IP) de votre Freebox Player et le code de la télécommande.",
+        "data": {
+          "host": "Hôte",
+          "remote_code": "Code de la télécommande"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "La Freebox Player est déjà configurée."
+    }
+  }
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,12 @@
+services:
+  homeassistant:
+    image: ghcr.io/home-assistant/home-assistant:stable
+    container_name: freebox_player_dev_ha
+    volumes:
+      # HA configuration + state (gitignored, seeded by scripts/dev-ha.sh)
+      - ./dev-config:/config
+      # Live-mount the integration so edits are picked up on restart
+      - ./custom_components:/config/custom_components:ro
+    ports:
+      - "8123:8123"
+    restart: unless-stopped

--- a/info.md
+++ b/info.md
@@ -1,107 +1,29 @@
-# Freebox Player Custom Component for Home Assistant
+# Freebox Player — Custom Component for Home Assistant
 
-Based on pure-python library, this custom component enables remote control on your Freebox Player devices.
+Control your Freebox Player from Home Assistant, emulating the network remote
+via the player's `remote_control` HTTP API.
 
-This component is tested on Freebox Delta, but should work too on FreeBox Revolution, mini and crystal (feedsback will be appreciated)
+## Compatibility
 
-## Features
-* Supports On / Off 
-* Supports changing channels
-* Supports volume changes
-* Supports navigation controls
-* Even more incoming
+Works with the **classic players** (Révolution, Delta player, One, Crystal).
 
-## Still under developpment
-This conponent use the old remote API, but since short time, Free is developping new API unrelated to remote (control player to open URL ect…)
+The **Freebox Pop** and **Mini 4K** run Android TV and do **not** expose this
+API — use Home Assistant's built-in **Android TV Remote** integration for them.
 
 ## Configuration
-Once installed, the Freebox Player component needs to be configured in order to work.
 
-Edit `configuration.yaml` file and add the following:
+Set up from the UI: **Settings → Devices & Services → Add Integration →
+Freebox Player**, then enter the player's **host** (IP) and **remote control
+code** (Player: *Réglages → Système → Informations → « Code télécommande
+réseau »*).
+
+## Usage
 
 ```yaml
-# Example configuration.yaml entry
-freebox_player:
-  remote_code: 00000000
-  host: 192.168.0.xx
+service: freebox_player.remote
+data:
+  code: "power"      # or several: "1,2,3"
 ```
 
-Where `remote_code` is the free authorization code for remote and `host` the ip of the player device.
-
-### How to get the remote control code
-
-Go to 
-* `Freebox main menu` >> `Parameters` >> `General Information` For old box
-* `Freebox main menu` >> `Réglages` >> `Systeme Information` For Delta 
-
-## How to use the remote
-
-To send remote code to the player, just call the service `freebox_player.remote` with the code in parameter: 
-```yaml
-code: "power"
-```
-
-### Mutiple code
-
-If you want to send multiple code like `123` for example, you need to split each code with a comma :
-```yaml
-code: "1,2,3"
-```
-
-Or you call multiple times the service for each number (`1` && `2` && `3`)
-
-
-## Button List
-
-* "red" // Bouton rouge
-* "green" // Bouton vert
-* "blue" // Bouton bleu
-* "yellow" // Bouton jaune
-
-* "power" // Bouton Power
-* "list" // Affichage de la liste des chaines
-* "tv" // Bouton tv
-
-* "1" // Bouton 1
-* "2" // Bouton 2
-* "3" // Bouton 3
-* "4" // Bouton 4
-* "5" // Bouton 5
-* "6" // Bouton 6
-* "7" // Bouton 7
-* "8" // Bouton 8
-* "9" // Bouton 9
-
-* "back" // Bouton jaune (retour)
-* "0" // Bouton 0
-* "swap" // Bouton swap
-
-* "info" // Bouton info
-* "epg" // Bouton epg (fct+)
-* "mail" // Bouton mail
-* "media" // Bouton media (fct+)
-* "help" // Bouton help
-* "options" // Bouton options (fct+)
-* "pip" // Bouton pip
-
-* "vol_inc" // Bouton volume +
-* "vol_dec" // Bouton volume -
-
-* "ok" // Bouton ok
-* "up" // Bouton haut
-* "right" // Bouton droite
-* "down" // Bouton bas
-* "left" // Bouton gauche
-
-* "prgm_inc" //Bouton programme +
-* "prgm_dec" // Bouton programme -
-
-* "mute" // Bouton sourdine
-* "home" // Bouton Free
-* "rec" // Bouton Rec
-
-* "bwd" // Bouton << retour arrière
-* "prev" // Bouton |<< précédent
-* "play" // Bouton Lecture / Pause
-* "fwd" // Bouton >> avance rapide
-* "next" // Bouton >>| suivant
+See the [README](https://github.com/Pouzor/freebox_player) for the full button
+list and details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.ruff]
 target-version = "py311"
 line-length = 100
-src = ["custom_components"]
+src = ["custom_components", "tests"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM"]
@@ -14,3 +14,7 @@ known-first-party = ["custom_components"]
 python_version = "3.11"
 ignore_missing_imports = true
 warn_unused_ignores = true
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+src = ["custom_components"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+ignore = ["E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["custom_components"]
+
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true
+warn_unused_ignores = true

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,1 @@
+pytest-homeassistant-custom-component

--- a/scripts/dev-ha.sh
+++ b/scripts/dev-ha.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Spin up Home Assistant in Docker with this integration mounted, for local
+# testing of the HACS component.
+#
+# Usage:
+#   ./scripts/dev-ha.sh           # start HA, follow logs
+#   ./scripts/dev-ha.sh stop      # stop the container
+#   ./scripts/dev-ha.sh restart   # restart container (picks up code edits)
+#   ./scripts/dev-ha.sh logs      # tail logs
+#   ./scripts/dev-ha.sh shell     # bash inside container
+#
+# After first start: open http://localhost:8123 -> onboard -> Settings ->
+# Devices & Services -> Add Integration -> "Freebox Player".
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+COMPOSE_FILE="docker-compose.dev.yml"
+SERVICE="homeassistant"
+
+ensure_config_dir() {
+  mkdir -p "$ROOT/dev-config"
+  # Seed a minimal config the first time, with debug logging for this domain.
+  if [[ ! -f "$ROOT/dev-config/configuration.yaml" ]]; then
+    echo "→ Seeding dev-config/configuration.yaml..."
+    cat >"$ROOT/dev-config/configuration.yaml" <<'YAML'
+default_config:
+
+logger:
+  default: info
+  logs:
+    custom_components.freebox_player: debug
+YAML
+  fi
+}
+
+cmd_up() {
+  ensure_config_dir
+  echo "→ Starting Home Assistant container..."
+  docker compose -f "$COMPOSE_FILE" up -d "$SERVICE"
+  echo
+  echo "✅ HA running at http://localhost:8123"
+  echo "   Add the integration via Settings → Devices & Services → \"Freebox Player\"."
+  echo "   Following logs (Ctrl+C to stop following — container keeps running)..."
+  echo
+  docker compose -f "$COMPOSE_FILE" logs -f "$SERVICE"
+}
+
+cmd_stop() {
+  echo "→ Stopping container..."
+  docker compose -f "$COMPOSE_FILE" down
+}
+
+cmd_restart() {
+  echo "→ Restarting container (picks up code edits)..."
+  docker compose -f "$COMPOSE_FILE" restart "$SERVICE"
+  docker compose -f "$COMPOSE_FILE" logs -f "$SERVICE"
+}
+
+cmd_logs() {
+  docker compose -f "$COMPOSE_FILE" logs -f "$SERVICE"
+}
+
+cmd_shell() {
+  docker compose -f "$COMPOSE_FILE" exec "$SERVICE" /bin/bash
+}
+
+case "${1:-up}" in
+  up|"")    cmd_up ;;
+  stop)     cmd_stop ;;
+  restart)  cmd_restart ;;
+  logs)     cmd_logs ;;
+  shell)    cmd_shell ;;
+  *)
+    echo "Unknown command: $1" >&2
+    echo "Usage: $0 [up|stop|restart|logs|shell]" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/freebox-check.py
+++ b/scripts/freebox-check.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Diagnostic autonome de l'API Player Freebox (nouvelle API via le serveur).
+
+But : confirmer que ton Player (ex. Freebox Pop) est bien exposé par le
+serveur (Delta) avant d'implémenter quoi que ce soit dans l'intégration.
+
+Ce script ne dépend que de la bibliothèque standard. Il :
+  1. demande l'autorisation à la Freebox (à valider sur l'écran LCD),
+  2. ouvre une session (challenge + HMAC-SHA1),
+  3. liste les players (GET /api/v6/player),
+  4. sauvegarde l'app_token dans .freebox-token.json (réutilisable).
+
+Usage :
+    python3 scripts/freebox-check.py            # host = mafreebox.freebox.fr
+    python3 scripts/freebox-check.py 192.168.1.254
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+APP_ID = "fr.freebox.player.ha"
+APP_NAME = "Home Assistant Freebox Player"
+APP_VERSION = "2.0.0"
+DEVICE_NAME = "Home Assistant"
+
+TOKEN_FILE = Path(__file__).resolve().parent.parent / ".freebox-token.json"
+
+
+def _call(host: str, method: str, path: str, body: dict | None = None,
+          token: str | None = None) -> dict:
+    url = f"http://{host}/api/v6{path}"
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Content-Type", "application/json")
+    if token:
+        req.add_header("X-Fbx-App-Auth", token)
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as err:
+        return json.loads(err.read())
+    except urllib.error.URLError as err:
+        sys.exit(f"❌ Connexion impossible à http://{host} : {err.reason}")
+
+
+def get_app_token(host: str) -> str:
+    if TOKEN_FILE.exists():
+        saved = json.loads(TOKEN_FILE.read_text())
+        if saved.get("host") == host and saved.get("app_token"):
+            print(f"→ app_token réutilisé depuis {TOKEN_FILE.name}")
+            return saved["app_token"]
+
+    print("→ Demande d'autorisation à la Freebox...")
+    res = _call(host, "POST", "/login/authorize/", {
+        "app_id": APP_ID,
+        "app_name": APP_NAME,
+        "app_version": APP_VERSION,
+        "device_name": DEVICE_NAME,
+    })
+    if not res.get("success"):
+        sys.exit(f"❌ authorize a échoué : {res}")
+
+    app_token = res["result"]["app_token"]
+    track_id = res["result"]["track_id"]
+
+    print("\n⚠️  VA SUR L'ÉCRAN LCD DE LA FREEBOX ET APPUIE SUR ✓ (flèche droite)\n")
+    while True:
+        status = _call(host, "GET", f"/login/authorize/{track_id}")["result"]["status"]
+        if status == "granted":
+            print("✓ Autorisation accordée.")
+            break
+        if status in ("denied", "timeout", "unknown"):
+            sys.exit(f"❌ Autorisation {status}.")
+        print(f"   en attente... ({status})")
+        time.sleep(2)
+
+    TOKEN_FILE.write_text(json.dumps({"host": host, "app_token": app_token}, indent=2))
+    print(f"→ app_token sauvegardé dans {TOKEN_FILE.name}")
+    return app_token
+
+
+def open_session(host: str, app_token: str) -> tuple[str, dict]:
+    challenge = _call(host, "GET", "/login/")["result"]["challenge"]
+    password = hmac.new(app_token.encode(), challenge.encode(), hashlib.sha1).hexdigest()
+    res = _call(host, "POST", "/login/session/", {"app_id": APP_ID, "password": password})
+    if not res.get("success"):
+        sys.exit(f"❌ session a échoué : {res}")
+    return res["result"]["session_token"], res["result"].get("permissions", {})
+
+
+def main() -> None:
+    host = sys.argv[1] if len(sys.argv) > 1 else "mafreebox.freebox.fr"
+    print(f"Freebox host : {host}\n")
+
+    app_token = get_app_token(host)
+    session_token, permissions = open_session(host, app_token)
+
+    print(f"\n→ Permissions accordées : {permissions}")
+    if not permissions.get("player"):
+        print("⚠️  La permission 'player' n'est PAS accordée.")
+        print("   Freebox OS → Paramètres → Gestion des accès → Applications →")
+        print(f"   '{APP_NAME}' → coche 'Modification des réglages du Player'.\n")
+
+    print("\n→ GET /api/v6/player ...")
+    res = _call(host, "GET", "/player/", token=session_token)
+    if not res.get("success"):
+        sys.exit(f"❌ Impossible de lister les players : {res}")
+
+    players = res.get("result", [])
+    if not players:
+        print("❌ AUCUN player listé. Ta Pop n'est pas exposée par le serveur.")
+        print("   (cf. FS#31235 — la nouvelle API ne pourra pas la piloter.)")
+        return
+
+    print(f"\n✅ {len(players)} player(s) trouvé(s) :\n")
+    for p in players:
+        flag = "✅" if (p.get("reachable") and p.get("api_available")) else "⚠️ "
+        print(f"  {flag} id={p.get('id')}  {p.get('device_name')}  "
+              f"stb={p.get('stb_type')}  api_version={p.get('api_version')}  "
+              f"reachable={p.get('reachable')}  api_available={p.get('api_available')}")
+
+    print("\nVerdict :")
+    ok = [p for p in players if p.get("reachable") and p.get("api_available")]
+    if ok:
+        print("  → Pilotable par la nouvelle API. On peut coder l'intégration. 🎉")
+    else:
+        print("  → Player listé mais non joignable / API indispo. À creuser avant de coder.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/security-check.sh
+++ b/scripts/security-check.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+echo "Running security checks..."
+
+# Check .env is not staged
+if git diff --cached --name-only | grep -E '^\.env$|^\.env\.' | grep -v '\.example$'; then
+  echo "ERROR: .env file is staged for commit!"
+  exit 1
+fi
+
+# Check for common secret patterns
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+if [ -n "$STAGED_FILES" ]; then
+  if echo "$STAGED_FILES" | xargs grep -l -E '(password|secret|api_key|apikey|token)\s*[:=]\s*["\047][^"\047]{8,}["\047]' 2>/dev/null; then
+    echo "WARNING: Possible secrets found in staged files - please verify"
+  fi
+fi
+
+echo "Security checks complete!"

--- a/scripts/verify-tooling.sh
+++ b/scripts/verify-tooling.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+echo "Verifying project tooling..."
+
+# Python
+if command -v python3 &> /dev/null; then
+  echo "✓ Python: $(python3 --version)"
+else
+  echo "✗ Python3 not installed"
+  exit 1
+fi
+
+# Ruff
+if command -v ruff &> /dev/null; then
+  echo "✓ Ruff installed"
+else
+  echo "⚠ Ruff not installed. Run: pip install ruff"
+fi
+
+# pre-commit
+if command -v pre-commit &> /dev/null; then
+  echo "✓ pre-commit installed"
+else
+  echo "⚠ pre-commit not installed. Run: pip install pre-commit && pre-commit install"
+fi
+
+# GitHub CLI
+if command -v gh &> /dev/null; then
+  if gh auth status &> /dev/null; then
+    echo "✓ GitHub CLI authenticated"
+  else
+    echo "✗ GitHub CLI not authenticated. Run: gh auth login"
+  fi
+else
+  echo "⚠ GitHub CLI not installed. Run: brew install gh"
+fi
+
+echo ""
+echo "Tooling verification complete!"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Freebox Player integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Shared fixtures for Freebox Player tests."""
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Enable loading of the custom integration in every test."""
+    yield

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -26,7 +26,7 @@ async def test_user_flow_creates_entry(hass: HomeAssistant) -> None:
 
 
 async def test_user_flow_aborts_if_already_configured(hass: HomeAssistant) -> None:
-    """A second entry for the same host is aborted."""
+    """A second entry is aborted (single_config_entry integration)."""
     MockConfigEntry(domain=DOMAIN, data=USER_INPUT, unique_id=USER_INPUT[CONF_HOST]).add_to_hass(
         hass
     )
@@ -34,9 +34,8 @@ async def test_user_flow_aborts_if_already_configured(hass: HomeAssistant) -> No
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    result = await hass.config_entries.flow.async_configure(result["flow_id"], USER_INPUT)
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result["reason"] == "single_instance_allowed"
 
 
 async def test_import_flow_creates_entry(hass: HomeAssistant) -> None:
@@ -58,4 +57,4 @@ async def test_import_flow_aborts_duplicate(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=USER_INPUT
     )
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result["reason"] == "single_instance_allowed"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,61 @@
+"""Tests for the Freebox Player config flow."""
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.freebox_player.const import CONF_REMOTE_CODE, DOMAIN
+
+USER_INPUT = {CONF_HOST: "192.168.0.10", CONF_REMOTE_CODE: "12345678"}
+
+
+async def test_user_flow_creates_entry(hass: HomeAssistant) -> None:
+    """A user-initiated flow creates a config entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], USER_INPUT)
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "192.168.0.10"
+    assert result["data"] == USER_INPUT
+
+
+async def test_user_flow_aborts_if_already_configured(hass: HomeAssistant) -> None:
+    """A second entry for the same host is aborted."""
+    MockConfigEntry(domain=DOMAIN, data=USER_INPUT, unique_id=USER_INPUT[CONF_HOST]).add_to_hass(
+        hass
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], USER_INPUT)
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_import_flow_creates_entry(hass: HomeAssistant) -> None:
+    """YAML import creates a config entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=USER_INPUT
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == USER_INPUT
+
+
+async def test_import_flow_aborts_duplicate(hass: HomeAssistant) -> None:
+    """Re-importing the same host is aborted."""
+    MockConfigEntry(domain=DOMAIN, data=USER_INPUT, unique_id=USER_INPUT[CONF_HOST]).add_to_hass(
+        hass
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=USER_INPUT
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,78 @@
+"""Tests for the Freebox Player setup and remote service."""
+
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
+
+from custom_components.freebox_player.const import (
+    CONF_REMOTE_CODE,
+    DOMAIN,
+    SERVICE_REMOTE,
+)
+
+ENTRY_DATA = {CONF_HOST: "192.168.0.10", CONF_REMOTE_CODE: "12345678"}
+BASE_URL = "http://192.168.0.10/pub/remote_control"
+
+
+async def _setup_entry(hass: HomeAssistant) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, data=ENTRY_DATA, unique_id=ENTRY_DATA[CONF_HOST])
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
+
+
+async def test_setup_registers_service(hass: HomeAssistant) -> None:
+    """Setting up an entry registers the remote service."""
+    await _setup_entry(hass)
+    assert hass.services.has_service(DOMAIN, SERVICE_REMOTE)
+
+
+async def test_unload_removes_service(hass: HomeAssistant) -> None:
+    """Unloading the entry removes the remote service."""
+    entry = await _setup_entry(hass)
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert not hass.services.has_service(DOMAIN, SERVICE_REMOTE)
+
+
+async def test_remote_service_sends_single_code(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Calling the service sends one request with the right params."""
+    aioclient_mock.get(BASE_URL, text="")
+    await _setup_entry(hass)
+
+    await hass.services.async_call(DOMAIN, SERVICE_REMOTE, {"code": "power"}, blocking=True)
+
+    assert len(aioclient_mock.mock_calls) == 1
+    _, url, _, _ = aioclient_mock.mock_calls[0]
+    assert url.query["code"] == "12345678"
+    assert url.query["key"] == "power"
+
+
+async def test_remote_service_splits_codes(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Comma-separated codes produce one request per code."""
+    aioclient_mock.get(BASE_URL, text="")
+    await _setup_entry(hass)
+
+    await hass.services.async_call(DOMAIN, SERVICE_REMOTE, {"code": "1, 2 ,3"}, blocking=True)
+
+    assert len(aioclient_mock.mock_calls) == 3
+    keys = [call[1].query["key"] for call in aioclient_mock.mock_calls]
+    assert keys == ["1", "2", "3"]
+
+
+async def test_remote_service_handles_http_error(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """A failing request is swallowed (logged, not raised)."""
+    aioclient_mock.get(BASE_URL, status=500)
+    await _setup_entry(hass)
+
+    # Should not raise despite the 500 response.
+    await hass.services.async_call(DOMAIN, SERVICE_REMOTE, {"code": "power"}, blocking=True)
+    assert len(aioclient_mock.mock_calls) == 1


### PR DESCRIPTION
## Summary

Major modernization of the integration to current Home Assistant standards.

- **Async rewrite + bug fix** — `__init__.py` now uses HA's aiohttp client (`async_get_clientsession`), dropping the undeclared sync `requests` dependency. Fixes a real bug where `'verify=False'` was passed positionally and silently became the request `params`; codes are now sent via proper `params={code, key}`, with per-code error handling.
- **UI config flow** — set up from the UI instead of editing `configuration.yaml`. Converts to the config-entry lifecycle (`async_setup_entry` / `async_unload_entry`). Existing YAML is auto-imported once, then removable. Marked `single_config_entry`.
- **Internationalization** — `strings.json` + English and French translations.
- **Tests** — pytest coverage (config flow, setup/unload, remote service incl. comma sequences and HTTP errors) via `pytest-homeassistant-custom-component`, plus a CI test job. CI also runs Ruff, hassfest and HACS validation, and TruffleHog.
- **Docs** — rewritten README/info.md with a compatibility table.

## Player compatibility

Investigated the open requests for the "new API" (#5, #11) and the Pop (#16). Findings, verified against a real Delta-server + Pop-player setup:

- The Pop / Mini 4K run Android TV (`stb_v8`) and expose **neither** the legacy `remote_control` API **nor** the Freebox OS Player API (`api_available: false`).
- The correct way to control them is Home Assistant's built-in **Android TV Remote** integration. The README now documents this.
- This component stays scoped to the classic players (Révolution, Delta player, One, Crystal).

## Developer tooling

- `scripts/dev-ha.sh` + `docker-compose.dev.yml` — run HA in Docker with the integration mounted.
- `scripts/freebox-check.py` — standalone diagnostic that authenticates to the server and lists players.

## Notes

- Manifest bumped `1.0.6` → `1.1.0`.
- No change to the public `freebox_player.remote` service for legacy players.